### PR TITLE
Test with new serde_v8 op-abi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,12 +46,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
-name = "cargo_gn"
-version = "0.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba7d7f7b201dfcbc314b14f2176c92f8ba521dab538b40e426ffed25ed7cd80"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,20 +53,20 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "deno_core"
-version = "0.77.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea6b5f04b9336050413741233eef45f01379ae7ac2ca88ff2ee1bb21081a131"
+version = "0.81.0"
 dependencies = [
  "anyhow",
+ "erased-serde",
  "futures",
  "indexmap",
  "lazy_static",
  "libc",
  "log",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "rusty_v8",
  "serde",
  "serde_json",
+ "serde_v8",
  "smallvec",
  "url",
 ]
@@ -87,6 +81,15 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0465971a8cc1fa2455c8465aaa377131e1f1cf4983280f474a13e68793aa770c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -294,7 +297,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "socket2",
  "tokio",
  "tower-service",
@@ -346,9 +349,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.84"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
+checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
 
 [[package]]
 name = "lock_api"
@@ -470,11 +473,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.4",
+ "pin-project-internal 1.0.5",
 ]
 
 [[package]]
@@ -490,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -549,12 +552,11 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "rusty_v8"
-version = "0.16.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f63f3030b5a676b9f6e7d53bf1f880904973c2350a3f034dbf82facca0b4f"
+checksum = "44bcf83fc222cc6caf4404414eae397c910e2f1ee31f291024434ae5cc312918"
 dependencies = [
  "bitflags",
- "cargo_gn",
  "fslock",
  "lazy_static",
  "libc",
@@ -595,13 +597,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "indexmap",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_v8"
+version = "0.0.0"
+dependencies = [
+ "rusty_v8",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 hyper = { version = "0.14", features = ["server", "stream", "http1", "http2", "runtime"] }
 tokio = { version = "1.1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["io"] }
-deno_core = "0.77.1"
+# deno_core = "0.81.0"
+deno_core = { version = "0.81.0", path = "../deno/core" }
 serde = "1.0"
 bytes = "1.0"

--- a/bench.bash
+++ b/bench.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+env RUSTFLAGS="-C debuginfo=1" cargo build --release
+# perf record -c 40000 -i -g target/release/dyper_ops --perf_basic_prof &
+target/release/dyper_ops &
+pid=$!
+sleep .5
+../deno/third_party/prebuilt/mac/wrk -d 20s --latency http://127.0.0.1:4000/
+kill $pid

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -8,9 +8,7 @@
 
   async function handleConn(connRid) {
     while (true) {
-      const request = await Deno.core.jsonOpAsync("op_next_request", {
-        rid: connRid,
-      });
+      const request = await Deno.core.jsonOpAsync("op_next_request", connRid);
       // Deno.core.print(`request ${JSON.stringify(request)}\n`);
       Deno.core.jsonOpSync("op_respond", {
         rid: connRid,
@@ -21,16 +19,14 @@
   }
 
   async function main() {
-    const { rid: serverRid } = await Deno.core.jsonOpAsync(
+    const serverRid = await Deno.core.jsonOpAsync(
       "op_create_server",
-      {},
+      null,
     );
     // Deno.core.print(`server rid ${serverRid}\n`);
 
     while (true) {
-      const { rid: connRid } = await Deno.core.jsonOpAsync("op_accept", {
-        rid: serverRid,
-      });
+      const connRid = await Deno.core.jsonOpAsync("op_accept", serverRid);
       // Deno.core.print(`conn rid ${connRid}\n`);
       handleConn(connRid);
     }


### PR DESCRIPTION
Draft benching `deno_hyper` with the new `deno` op-ABI (https://github.com/denoland/deno/pull/9843).

Throughput benched on my local machine (m1 Air):
- `server`: ~60k/s
- `server` (new): ~80k/s
- `node_http.js`: ~80k/s